### PR TITLE
chore(docs): Claude/Cursor, README — org Project cookie

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -14,3 +14,13 @@
 - Спецификация в **vault**; issues — структура из `.github/ISSUE_TEMPLATE/task.yml`.
 - Контракт API: swagger бэкенда; dev — **MSW** на `/api/v1/*` согласно tech-stack.
 - Зеркало/диаграммы: репозиторий [architecture](https://github.com/COOKieProjectTeam/architecture).
+
+### Dev / качество перед PR
+
+- **MSW ↔ реальный API:** в разработке мокируется только префикс **`/api/v1/*`**; при включении живого backend задайте `NEXT_PUBLIC_*`/`NEXT_PUBLIC_API_BASE_URL` в **`.env.local`** (образец — **`.env.example`** в корне репо). После правок конфигурации проверять и мок-сценарии, и хит реального swagger.
+- **Маршруты:** только **Next.js App Router**, страницы и layouts в **`src/app/`**; не смешивать с legacy `pages/` без явной задачи на миграцию.
+- **Проверки локально перед PR:** `npm run lint` → `npm run build` (включает typecheck сборки Next) → `npm test`; при ошибках сборки править перед отправкой ревью.
+
+### Организационная доска
+
+- Единый org Projects **«cookie»**, workflow добавления новых issue: см. [github-project-cookie](https://github.com/COOKieProjectTeam/architecture/blob/main/docs/process/github-project-cookie.md).

--- a/.claude/rules/sot-and-issues.md
+++ b/.claude/rules/sot-and-issues.md
@@ -12,6 +12,8 @@
 
 **Companion:** при вертикали указывать issue в `cookie-backend`.
 
+**Организационная доска:** Projects v2 org **«cookie»** — карточки issue/PR; область задачи задаётся метками **`area:frontend`**, **`area:backend`**, **`area:infra`**, **`area:docs`**. Полный процесс: зеркало [github-project-cookie](https://github.com/COOKieProjectTeam/architecture/blob/main/docs/process/github-project-cookie.md).
+
 ## Pull Request
 
 - **`main`** защищён: только ветка + **PR**. См. `.claude/rules/protected-main.md`.

--- a/.cursor/rules/cookie-frontend.mdc
+++ b/.cursor/rules/cookie-frontend.mdc
@@ -15,11 +15,13 @@ alwaysApply: false
 - **Тексты требований и UI (канон):** Obsidian vault — `Knowledge/Development/Projects/COOKie/` (SRS/FRS и др.); не вставлять полные тексты спеки в issues.
 - **Формат issues:** `.github/ISSUE_TEMPLATE/task.yml`; процесс — `Knowledge/Development/Projects/COOKie/process/github-issue-format.md` в vault.
 - **Техстек канон:** vault `architecture/technical/tech-stack.md` — **Next.js 14** (App Router), **React 18**, **TypeScript 5**, TanStack Query 5, Zustand 4, styled-components 6, React Hook Form + Zod, Axios, **MSW** в dev против `/api/v1/*` по **swagger**. При расхождении с зависимостями репо — правьте код/депы к канону или оформляйте CR.
+- **Не тащите полный SRS/FRS в PR:** истина процесса — **vault**, **поля/issue с Trace**, последний контракт **swagger** кодового backend и утверждённые golden paths этого репозитория после появления кода.
 
 ## Практика
 
 - Вертикаль с API: в задачах заполнять **Companion** → `cookie-backend`.
 - Структура каталогов — FSD-подобная раскладка из tech-stack (`app/`, `features/`, `entities/`, `shared/`).
+- **Доска org:** один Projects **«cookie»** ([HTTPS](https://github.com/orgs/COOKieProjectTeam/projects/2)), для области работы использовать метки **`area:frontend`** / **`area:backend`** / **`area:infra`** / **`area:docs`** там, где задача не однозначно «этот компонент»; подробнее в зеркале [github-project-cookie](https://github.com/COOKieProjectTeam/architecture/blob/main/docs/process/github-project-cookie.md).
 
 ## Защищённый `main`
 

--- a/README.md
+++ b/README.md
@@ -158,13 +158,13 @@ npm run test:ui
 - Keep components small and focused
 - Co-locate tests with components
 
+## GitHub Projects v2 («cookie»)
+
+Новые **issues** в этом репозитории автоматически попадают в org-проект [cookie (#2)](https://github.com/orgs/COOKieProjectTeam/projects/2). Для успешной работы GitHub Actions задайте в настройках репозитория секрет **`ADD_TO_PROJECT_PAT`** (scopes и проверку — см. [github-project-cookie](https://github.com/COOKieProjectTeam/architecture/blob/main/docs/process/github-project-cookie.md)).
+
 ## Contributing
 
-1. Follow the [Git Workflow Guide](https://github.com/COOKAITeam/architecture/blob/main/docs/guides/git_workflow.md)
-2. Always link PRs to architecture docs
-3. Ensure tests pass before pushing
-4. Update documentation if needed
-
-## License
+1. Workflow веток: ветка → PR в `main`; ссылку на issue в тексте PR (`Closes #N` / `Refs #N`). Подробнее: [.claude/rules/protected-main.md](.claude/rules/protected-main.md).
+2. Спецификация и дорожная карта: репозиторий [architecture](https://github.com/COOKieProjectTeam/architecture) (`docs/`), синхронизация с Vault — см. `docs/SYNC.md`.
 
 Proprietary - COOKie Team


### PR DESCRIPTION
- Extends \.claude/CLAUDE.md\ (MSW vs API, env, App Router checklist, lint/build/test, project link).\n- \sot-and-issues.md\, \.cursor/rules/cookie-frontend.mdc\: org Projects **cookie**, \rea:*\ labels, SoT wording.\n- README: Contributing points to PAT + architecture doc.\n\n**Workflow file:** OAuth token here lacks scope \workflow\; YAML lives locally on branch \ci/org-project-issue-workflow\ (same content as embedded in architecture doc). Either \gh auth refresh -h github.com -s workflow\ and push that branch, or add \.github/workflows/add-issue-to-org-project.yml\ via GitHub UI from [github-project-cookie](https://github.com/COOKieProjectTeam/architecture/blob/chore/docs-github-project-cookie/docs/process/github-project-cookie.md) after merge.