### PR TITLE
fix: root-relative .claude path patterns in protect-files

### DIFF
--- a/.claude/hooks/protect-files.sh
+++ b/.claude/hooks/protect-files.sh
@@ -68,9 +68,9 @@ case "$PATH_LC" in
     emit deny "Cannot edit files inside secrets/" ;;
   */.env|*/.env.*)
     emit deny "Cannot edit .env files" ;;
-  */.claude/hooks/*)
+  .claude/hooks/*|*/.claude/hooks/*)
     emit deny "Cannot edit hook scripts. These enforce security boundaries." ;;
-  */.claude/settings.json|*/.claude/settings.local.json)
+  .claude/settings.json|.claude/settings.local.json|*/.claude/settings.json|*/.claude/settings.local.json)
     emit ask "Editing settings.json controls permissions and hooks. Confirm this change." ;;
 esac
 


### PR DESCRIPTION
## Summary

- Pattern `*/.claude/hooks/*` requires a path component before `.claude` — doesn't match `.claude/hooks/file.sh` when project is opened as workspace root
- Same issue with `*/.claude/settings.json`
- Added root-relative variants: `.claude/hooks/*` and `.claude/settings.json`

## Test plan

- [x] `echo '{"tool_input":{"file_path":".claude/hooks/protect-files.sh"}}' | bash .claude/hooks/protect-files.sh` → exit 2 (deny)
- [x] `echo '{"tool_input":{"file_path":".claude/settings.json"}}' | bash .claude/hooks/protect-files.sh` → exit 2 (ask)