### PR TITLE
chore: fix issue template and PR template refs

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,12 +1,12 @@
 name: Task — feature / sprint work
-description: Задача с трассировкой к vault (frontend: UI, UX, клиентское состояние)
+description: Задача с трассировкой к architecture repo (frontend: UI, UX, клиентское состояние)
 title: '[S+] UI: '
 labels: []
 body:
   - type: markdown
     attributes:
       value: |
-        **cookie-frontend:** опишите экраны, состояния загрузки/ошибок, доступность и связь с API. В **Companion** укажите номер парной задачи в **cookie-backend**, если нужен контракт/API. Структура секций — см. vault `Knowledge/Development/Projects/COOKie/process/github-issue-format.md`.
+        **cookie-frontend:** опишите экраны, состояния загрузки/ошибок, доступность и связь с API. В **Companion** укажите номер парной задачи в **cookie-backend**, если нужен контракт/API. Структура секций — см. [github-issue-format.md](https://github.com/COOKieProjectTeam/architecture/blob/main/docs/process/github-issue-format.md) в architecture repo.
   - type: textarea
     id: goal
     attributes:
@@ -23,11 +23,11 @@ body:
     id: trace
     attributes:
       label: Trace
-      description: FR (обязательно). Опционально UC, NFR. Строка «Vault:» — путь к заметке в Obsidian.
+      description: FR (обязательно). Опционально UC, NFR. Строка «Ref:» — ссылка на architecture repo.
       placeholder: |
         - FR: FR-US-001
         - NFR: …
-        - Vault: Knowledge/Development/Projects/COOKie/requirements/FRS.md §…
+        - Ref: https://github.com/COOKieProjectTeam/architecture/blob/main/docs/requirements/FRS.md §…
     validations:
       required: true
   - type: textarea

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,6 @@
 ## Architecture Reference
 <!-- Link to relevant architecture documentation (if applicable) -->
 
-
 ## Type of Change
 <!-- Mark with "x" the relevant option(s) -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
@@ -24,9 +23,9 @@
 
 ## Checklist
 <!-- Mark with "x" all that apply -->
-- [ ] Code follows project style guide
+- [ ] Code follows project style guide (eslint / prettier pass)
 - [ ] Self-review completed
-- [ ] Comments added in hard-to-understand areas
+- [ ] Non-obvious logic has a comment explaining WHY (not what)
 - [ ] Documentation updated (if needed)
 - [ ] No console errors or warnings
 - [ ] Tests pass locally
@@ -36,12 +35,9 @@
 ## Screenshots (if applicable)
 <!-- Add screenshots or screen recordings for UI changes -->
 
-
 ## Related Issues
 <!-- Link related issues using keywords: Closes, Fixes, Resolves, Implements, Related -->
-<!-- Example: Closes #123, Implements COOKAITeam/architecture#FRONT-001 -->
-
+<!-- Example: Closes #123, Refs https://github.com/COOKieProjectTeam/architecture/blob/main/docs/requirements/FRS.md -->
 
 ## Additional Notes
 <!-- Any additional information for reviewers -->
-


### PR DESCRIPTION
## Summary

- Fix `task.yml`: vault refs → architecture repo links; update description and Trace placeholder
- Fix `PULL_REQUEST_TEMPLATE.md`: `COOKAITeam` → `COOKieProjectTeam`; checklist item "comments in hard-to-understand areas" → "WHY comment"

## Related Issues

Refs https://github.com/COOKieProjectTeam/architecture/blob/main/docs/process/github-issue-format.md